### PR TITLE
post message text includes creation date and artist, improve image description

### DIFF
--- a/helpers/mastodon.py
+++ b/helpers/mastodon.py
@@ -15,11 +15,6 @@ mastodon = Mastodon(
   api_base_url = mastodon_api_base_url,
 )
 
-def build_message(details: Dict[str, any]) -> str:
-    artist_url = details['extmetadata']['Artist']['value']
-    creation_time = details['extmetadata']['DateTimeOriginal']['value']
-    return f"<a href=\"{details['descriptionurl']}\">{creation_time}</a> by {artist_url}"
-
 def post(file: Dict[str, any]) -> None:
   try:
     details = get_file_details(file['title'])
@@ -27,8 +22,7 @@ def post(file: Dict[str, any]) -> None:
     alt_text = details['extmetadata']['ImageDescription']['value']
     resized_image  = fit_image_to_constraint(image, 4096)
     media_id = mastodon.media_post(to_bytes(resized_image), 'image', description=alt_text)['id']
-    text = build_message(details)
-    mastodon.status_post(text, media_ids=[media_id])
+    mastodon.status_post('', media_ids=[media_id])
   except Exception as e:
     print('Error posting to Mastodon')
     print(e)

--- a/helpers/mastodon.py
+++ b/helpers/mastodon.py
@@ -15,13 +15,20 @@ mastodon = Mastodon(
   api_base_url = mastodon_api_base_url,
 )
 
+def build_message(details: Dict[str, any]) -> str:
+    artist_url = details['extmetadata']['Artist']['value']
+    creation_time = details['extmetadata']['DateTimeOriginal']['value']
+    return f"<a href=\"{details['descriptionurl']}\">{creation_time}</a> by {artist_url}"
+
 def post(file: Dict[str, any]) -> None:
   try:
     details = get_file_details(file['title'])
     image = get_image(details['url'])
+    alt_text = details['extmetadata']['ImageDescription']['value']
     resized_image  = fit_image_to_constraint(image, 4096)
-    media_id = mastodon.media_post(to_bytes(resized_image), 'image', description=details['descriptionurl'])['id']
-    mastodon.status_post('', media_ids=[media_id])
+    media_id = mastodon.media_post(to_bytes(resized_image), 'image', description=alt_text)['id']
+    text = build_message(details)
+    mastodon.status_post(text, media_ids=[media_id])
   except Exception as e:
     print('Error posting to Mastodon')
     print(e)

--- a/helpers/twitter.py
+++ b/helpers/twitter.py
@@ -16,11 +16,6 @@ api = tweepy.API(auth)
 client = tweepy.Client(consumer_key=consumer_key, consumer_secret=consumer_secret,
                        access_token=access_token, access_token_secret=access_token_secret)
 
-def build_message(details: Dict[str, any]) -> str:
-    artist_url = details['extmetadata']['Artist']['value']
-    creation_time = details['extmetadata']['DateTimeOriginal']['value']
-    return f"{creation_time} by {artist_url} ({details['descriptionurl']})"
-
 def post(file: Dict[str, any]) -> None:
   try:
     details = get_file_details(file['title'])
@@ -29,8 +24,7 @@ def post(file: Dict[str, any]) -> None:
     resized_image  = fit_image_to_constraint(image, 2048)
     media_upload = api.simple_upload(f'image.{image.format}', file=to_bytes(resized_image))
     api.create_media_metadata(media_upload.media_id, alt_text=alt_text)
-    text = build_message(details)
-    client.create_tweet(text=text, media_ids=[media_upload.media_id])
+    client.create_tweet(media_ids=[media_upload.media_id])
   except Exception as e:
     print('Error posting to Twitter')
     print(e)

--- a/helpers/twitter.py
+++ b/helpers/twitter.py
@@ -16,15 +16,21 @@ api = tweepy.API(auth)
 client = tweepy.Client(consumer_key=consumer_key, consumer_secret=consumer_secret,
                        access_token=access_token, access_token_secret=access_token_secret)
 
+def build_message(details: Dict[str, any]) -> str:
+    artist_url = details['extmetadata']['Artist']['value']
+    creation_time = details['extmetadata']['DateTimeOriginal']['value']
+    return f"{creation_time} by {artist_url} ({details['descriptionurl']})"
+
 def post(file: Dict[str, any]) -> None:
   try:
     details = get_file_details(file['title'])
-    description_url = details['descriptionurl']
+    alt_text = details['extmetadata']['ImageDescription']['value']
     image = get_image(details['url'])
     resized_image  = fit_image_to_constraint(image, 2048)
     media_upload = api.simple_upload(f'image.{image.format}', file=to_bytes(resized_image))
-    api.create_media_metadata(media_upload.media_id, alt_text=description_url)
-    client.create_tweet(media_ids=[media_upload.media_id])
+    api.create_media_metadata(media_upload.media_id, alt_text=alt_text)
+    text = build_message(details)
+    client.create_tweet(text=text, media_ids=[media_upload.media_id])
   except Exception as e:
     print('Error posting to Twitter')
     print(e)

--- a/helpers/wikimedia.py
+++ b/helpers/wikimedia.py
@@ -68,7 +68,7 @@ def get_file_details(file_title: str) -> Dict[str, any]:
     'format': 'json',
     'titles': [file_title],
     'prop': 'imageinfo',
-    'iiprop': 'url',
+    'iiprop': 'extmetadata|url',
   }
   result = requests.get('https://commons.wikimedia.org/w/api.php', params=request).json()
   result_list = list(result['query']['pages'].values())


### PR DESCRIPTION
Hi,

So far the image description only contained the link to the source url. This was not very accessibility friendly as people with visual impairment would not get a proper description of the posted image. Meanwhile, for people who want to get to the source page couldn't do so, as they would need to copy the URL from the former alt text. With this change, the image author, creation time and source url are provided in the post text and the image description given by the API is posted as alt text.

Hope you can merge this. I tested the changes locally, but did not run fully run the bot.
Daniel