### PR TITLE
filter HTML from alt-descriptions

### DIFF
--- a/helpers/mastodon.py
+++ b/helpers/mastodon.py
@@ -1,3 +1,4 @@
+import re
 from typing import Dict
 from helpers.images import fit_image_to_constraint, get_image, to_bytes
 from mastodon import Mastodon
@@ -20,6 +21,7 @@ def post(file: Dict[str, any]) -> None:
     details = get_file_details(file['title'])
     image = get_image(details['url'])
     alt_text = details['extmetadata']['ImageDescription']['value']
+    alt_text = re.sub('<[^<]+?>', '', alt_text)
     resized_image  = fit_image_to_constraint(image, 4096)
     media_id = mastodon.media_post(to_bytes(resized_image), 'image', description=alt_text)['id']
     mastodon.status_post('', media_ids=[media_id])

--- a/helpers/twitter.py
+++ b/helpers/twitter.py
@@ -1,3 +1,4 @@
+import re
 import tweepy
 from boto3 import client
 from typing import Dict
@@ -20,6 +21,7 @@ def post(file: Dict[str, any]) -> None:
   try:
     details = get_file_details(file['title'])
     alt_text = details['extmetadata']['ImageDescription']['value']
+    alt_text = re.sub('<[^<]+?>', '', alt_text)
     image = get_image(details['url'])
     resized_image  = fit_image_to_constraint(image, 2048)
     media_upload = api.simple_upload(f'image.{image.format}', file=to_bytes(resized_image))


### PR DESCRIPTION
Hi,

Often the image descriptions comes with HTML tags from the API. These tags make no sense within the alt-tag of the image, so this filters them out.

Regards,
Dahie
